### PR TITLE
avoid restore_scroll conflicting with navigation by detecting change in selection

### DIFF
--- a/BufferScroll.py
+++ b/BufferScroll.py
@@ -319,6 +319,10 @@ class BufferScroll(sublime_plugin.EventListener):
 
                 if id in db:
 
+                    # if navigation changed selection don't restore scroll
+                    if db[id]['s'] != [[item.a, item.b] for item in view.sel()]:
+                        return
+
                     # scroll
                     if Pref.get('i_use_cloned_views', view) and index in db[id]['l']:
                         position = tuple(db[id]['l'][index])


### PR DESCRIPTION
this seems to fix some of the conflicts but I'm not sure if it has side effects
(issue #4)
